### PR TITLE
attempt to play every second if on mobile

### DIFF
--- a/components/_organisms/VideoStream/index.tsx
+++ b/components/_organisms/VideoStream/index.tsx
@@ -65,6 +65,22 @@ const VideoStream = ({
     }
   }, [remoteStream]);
 
+  useEffect(() => {
+    const interval = setInterval(() => {
+      if (playing) {
+        try {
+          videoRef.current?.play();
+        } catch {
+          console.log("failed to start video feed on timer");
+        }
+      }
+    }, 1000); // im not proud of this
+
+    return () => {
+      clearInterval(interval);
+    };
+  }, [playing]);
+
   return (
     <video
       preload="metadata"


### PR DESCRIPTION
Stream still sometimes doesn't play on certain devices, cant reproduce but have seen on other peoples physical devices. 

Can't even reproduce in browserstack 😅 

This is mainly driven by apple wanting user interaction with the page before the stream starts, so the new approach is to just keep trying to play the stream lol